### PR TITLE
Using buffer to perform output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ pub fn execute() -> Result<()> {
     let cli = Cli::parse();
 
     let data = read_data(cli.skip, cli.length, &cli.filename)?;
-    display_data(cli.skip, &data);
+    display_data(cli.skip, &data)?;
 
     Ok(())
 }


### PR DESCRIPTION
We got a nice performance boost using  a cursor as buffer.

❯ hyperfine --warmup 20 './mhv $(which mhv)' 'mhv $(which mhv)' Benchmark 1: ./mhv $(which mhv)
  Time (mean ± σ):     494.6 ms ±   3.7 ms    [User: 477.1 ms, System: 13.1 ms]
  Range (min … max):   491.0 ms … 504.0 ms    10 runs

Benchmark 2: mhv $(which mhv)
  Time (mean ± σ):     662.3 ms ±   5.2 ms    [User: 598.2 ms, System: 59.1 ms]
  Range (min … max):   655.8 ms … 671.4 ms    10 runs

Summary
  ./mhv $(which mhv) ran
    1.34 ± 0.01 times faster than mhv $(which mhv)