### PR TITLE
Remove to_string() in main function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod cli;
 
 fn main() {
     execute().unwrap_or_else(|e| {
-        eprintln!("Something wrong happened: {}", e.to_string());
+        eprintln!("Something wrong happened: {e}");
         std::process::exit(1);
     });
 }


### PR DESCRIPTION
Jus following the clippy lint. No need for it.